### PR TITLE
Make the turtlebots compatible with ros kinetic

### DIFF
--- a/tams_turtlebot_bringup/launch/sensors.launch
+++ b/tams_turtlebot_bringup/launch/sensors.launch
@@ -11,14 +11,14 @@
     <arg name="scan_topic" value="kinect_scan" />
   </include>
 
-  <!-- Laser -->
-  <node name="hokuyo_laser" pkg="hokuyo_node" type="hokuyo_node">
-    <param name="calibrate_time" type="bool" value="true"/>
-    <param name="intensity" type="bool" value="false"/>
+  <!-- laser -->
+  <node name="hokuyo_laser" pkg="urg_node" type="urg_node">
+    <param name="calibrate_time" type="bool" value="true" />
+    <param name="intensity" type="bool" value="false" />
     <param name="frame_id" value="/laser_link" />
     <param name="max_ang" type="double" value="2.356194437" />
     <param name="min_ang" type="double" value="-2.35619443" />
-    <param name="cluster" value="1"/>
+    <param name="cluster" value="1" />
     <param name="port" value="/dev/laser" />
     <remap from="scan" to="laser_scan" />
   </node>

--- a/tams_turtlebot_bringup/launch/tams_turtlebot.launch
+++ b/tams_turtlebot_bringup/launch/tams_turtlebot.launch
@@ -33,6 +33,8 @@
     <arg name="battery" value="$(env TURTLEBOT_BATTERY)" />
   </include>
 
+<!--
   <include file="$(find tams_turtlebot_bringup)/launch/capabilities.launch" />
+-->
 
 </launch>

--- a/tams_turtlebot_description/robots/kobuki_hexagons_kinect_hokuyo_04lx.urdf.xacro
+++ b/tams_turtlebot_description/robots/kobuki_hexagons_kinect_hokuyo_04lx.urdf.xacro
@@ -7,11 +7,8 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" /> 
+  <xacro:include filename="$(find turtlebot_description)/robots/kobuki_hexagons_kinect.urdf.xacro" />
   <xacro:include filename="$(find tams_turtlebot_description)/urdf/sensors/hokuyo_04lx.urdf.xacro" /> 
  
-  <kobuki/>
-  <stack_hexagons parent="base_link"/>
-  <sensor_kinect  parent="base_link"/>
   <hokuyo_04lx    parent="base_link"/>
 </robot>

--- a/tams_turtlebot_description/robots/kobuki_hexagons_kinect_hokuyo_30lx.urdf.xacro
+++ b/tams_turtlebot_description/robots/kobuki_hexagons_kinect_hokuyo_30lx.urdf.xacro
@@ -7,12 +7,8 @@
 -->    
 <robot name="turtlebot" xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:include filename="$(find turtlebot_description)/urdf/turtlebot_library.urdf.xacro" />
+  <xacro:include filename="$(find turtlebot_description)/robots/kobuki_hexagons_kinect.urdf.xacro" />
   <xacro:include filename="$(find tams_turtlebot_description)/urdf/sensors/hokuyo_30lx.urdf.xacro" />
   
-  <kobuki/>
-  <stack_hexagons parent="base_link"/>
-  <sensor_kinect  parent="base_link"/>
-  <!--<hokuyo_30lx    name="laser" parent="base" ros_topic="/scan" update_rate="20" min_angle="-1.57" max_angle="1.57" />-->
   <hokuyo_30lx    parent="base_link"/>
 </robot>

--- a/tams_turtlebot_navigation/launch/gmapping.launch
+++ b/tams_turtlebot_navigation/launch/gmapping.launch
@@ -4,7 +4,7 @@
   <include file="$(find tams_turtlebot_bringup)/launch/tams_turtlebot.launch" />
 
 <!-- Gmapping -->
-  <include file="$(find turtlebot_navigation)/launch/includes/gmapping.launch.xml"/>
+  <include file="$(find turtlebot_navigation)/launch/includes/gmapping/kinect_gmapping.launch.xml"/>
 
   <!-- Move base -->
   <include file="$(find turtlebot_navigation)/launch/includes/move_base.launch.xml"/>


### PR DESCRIPTION
The following changes were made to make the turtlebots compatible with ros kinetic:
- Change from `hokuyo_node` to `urg_node`, because the `hokuyo_node` is deprecated and the urg_node provides support for kinetic.
- Comment out `capabilities.launch` in `tams_turtlebot.launch`, because the `rocon_app_manager` does not function properly at the moment and is usually not needed anyway. 
- Adapt our xacro files to the changes made in the `turtlebot_description` package. 
- Adjust a path of an xml file for gmapping, due to changes in the `turtlebot_navigation` package.