### PR TITLE
Fix gmapping laser scan offset and max range issue

### DIFF
--- a/tams_turtlebot_bringup/launch/sensors.launch
+++ b/tams_turtlebot_bringup/launch/sensors.launch
@@ -12,12 +12,23 @@
   </include>
 
   <!-- laser -->
-  <node name="hokuyo_laser" pkg="urg_node" type="urg_node">
+  <node name="hokuyo_laser" pkg="urg_node" type="urg_node" if="$(eval env('TURTLEBOT_LASER') == 'hokuyo_04lx')">
     <param name="calibrate_time" type="bool" value="true" />
     <param name="intensity" type="bool" value="false" />
     <param name="frame_id" value="/laser_link" />
-    <param name="max_ang" type="double" value="2.356194437" />
-    <param name="min_ang" type="double" value="-2.35619443" />
+    <param name="angle_max" type="double" value="2.09234976768" />
+    <param name="angle_min" type="double" value="-2.09234976768" />
+    <param name="cluster" value="1" />
+    <param name="port" value="/dev/laser" />
+    <remap from="scan" to="laser_scan" />
+  </node>
+
+  <node name="hokuyo_laser" pkg="urg_node" type="urg_node" if="$(eval env('TURTLEBOT_LASER') == 'hokuyo_30lx')">
+    <param name="calibrate_time" type="bool" value="true" />
+    <param name="intensity" type="bool" value="false" />
+    <param name="frame_id" value="/laser_link" />
+    <param name="angle_max" type="double" value="2.356194437" />
+    <param name="angle_min" type="double" value="-2.35619443" />
     <param name="cluster" value="1" />
     <param name="port" value="/dev/laser" />
     <remap from="scan" to="laser_scan" />

--- a/tams_turtlebot_navigation/launch/gmapping.launch
+++ b/tams_turtlebot_navigation/launch/gmapping.launch
@@ -48,6 +48,5 @@
     <param name="llsamplestep" value="0.01"/>
     <param name="lasamplerange" value="0.005"/>
     <param name="lasamplestep" value="0.005"/>
-    <remap from="scan" to="laser_scan"/>
   </node>
 </launch>

--- a/tams_turtlebot_navigation/launch/gmapping.launch
+++ b/tams_turtlebot_navigation/launch/gmapping.launch
@@ -3,10 +3,51 @@
 
   <include file="$(find tams_turtlebot_bringup)/launch/tams_turtlebot.launch" />
 
-<!-- Gmapping -->
-  <include file="$(find turtlebot_navigation)/launch/includes/gmapping/kinect_gmapping.launch.xml"/>
-
-  <!-- Move base -->
+<!-- Move base -->
   <include file="$(find turtlebot_navigation)/launch/includes/move_base.launch.xml"/>
 
+  <node pkg="gmapping" type="slam_gmapping" name="slam_gmapping" output="screen">
+    <param name="base_frame" value="base_footprint"/>
+    <param name="odom_frame" value="odom"/>
+    <param name="map_update_interval" value="5.0"/>
+    <!-- use range parameter from the laser scan messages to support laser scanner + kinect -->
+    <!-- <param name="maxUrange" value="6.0"/> -->
+    <!-- <param name="maxRange" value="8.0"/> -->
+    <param name="sigma" value="0.05"/>
+    <param name="kernelSize" value="1"/>
+    <param name="lstep" value="0.05"/>
+    <param name="astep" value="0.05"/>
+    <param name="iterations" value="5"/>
+    <param name="lsigma" value="0.075"/>
+    <param name="ogain" value="3.0"/>
+    <param name="lskip" value="0"/>
+    <param name="minimumScore" value="200"/>
+    <param name="srr" value="0.01"/>
+    <param name="srt" value="0.02"/>
+    <param name="str" value="0.01"/>
+    <param name="stt" value="0.02"/>
+    <param name="linearUpdate" value="0.5"/>
+    <param name="angularUpdate" value="0.436"/>
+    <param name="temporalUpdate" value="-1.0"/>
+    <param name="resampleThreshold" value="0.5"/>
+    <param name="particles" value="80"/>
+  <!--
+    <param name="xmin" value="-50.0"/>
+    <param name="ymin" value="-50.0"/>
+    <param name="xmax" value="50.0"/>
+    <param name="ymax" value="50.0"/>
+  make the starting size small for the benefit of the Android client's memory...
+  -->
+    <param name="xmin" value="-1.0"/>
+    <param name="ymin" value="-1.0"/>
+    <param name="xmax" value="1.0"/>
+    <param name="ymax" value="1.0"/>
+
+    <param name="delta" value="0.05"/>
+    <param name="llsamplerange" value="0.01"/>
+    <param name="llsamplestep" value="0.01"/>
+    <param name="lasamplerange" value="0.005"/>
+    <param name="lasamplestep" value="0.005"/>
+    <remap from="scan" to="laser_scan"/>
+  </node>
 </launch>


### PR DESCRIPTION
The minimum and maximum angle was not set correctly in the driver for the
Hokuyo 04lx. This lead to an offset in gmapping. Now,we use different values for the 04lx and the 30lx.

Also, gmapping's maxRange parameter was set to a higher value, than the max range of the Hokuyo 04lx actually is. So, the max range values of the 04lx were used to build the map.
We do not set that parameter anymore, so that gmapping uses the values from the laser scan message.